### PR TITLE
Replace ceilingjars behavior 'FoodShelves.CeilingAttachable' with 'Unstable'

### DIFF
--- a/assets/foodshelves/blocktypes/glassware/ceilingjar.json
+++ b/assets/foodshelves/blocktypes/glassware/ceilingjar.json
@@ -23,7 +23,7 @@
     "unifyItemSlots": true
   },
   "behaviors": [
-    { "name": "FoodShelves.CeilingAttachable" }
+    { "name": "Unstable", "properties": { "attachedToFaces": ["up"] } }
   ],
   "shape": {
     "base": "block/glassware/ceilingjar"


### PR DESCRIPTION
Simple adjustment that makes use of the built-in Unstable behavior which implements the same functionality as CeilingAttachable, but also supports chiseled blocks.